### PR TITLE
Shrinked the container image generated by the docker compose command

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -25,8 +25,4 @@ COPY ./pkey "$SERVER_SSL_PKEY_FILE"
 COPY ./conf /etc/apache2/sites-available/000-default.conf
 RUN a2ensite 000-default && a2dissite default-ssl
 
-# Restart Apache to apply changes
-RUN service apache2 restart
-
-# Make the ports 80 and 443 available to the world outside this container
-EXPOSE 80 443
+# END

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,28 +2,31 @@ FROM php:8.2-apache
 
 # ---
 
-RUN apt-get update
+RUN apt-get update && apt-get install -y libpq-dev \
+    && docker-php-ext-install pdo pdo_pgsql \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+# Clean the apt cache to reduce the image size after installing the packages
 
 # ---
 
-RUN apt-get install -y libpq-dev
-RUN docker-php-ext-install pdo pdo_pgsql
-
-# ---
-
-RUN a2enmod rewrite
-RUN a2enmod ssl
+RUN a2enmod rewrite ssl
 
 # ---
 
 ARG SERVER_SSL_CERT_FILE
 ARG SERVER_SSL_PKEY_FILE
 
-COPY ./cert $SERVER_SSL_CERT_FILE
-COPY ./pkey $SERVER_SSL_PKEY_FILE
+COPY ./cert "$SERVER_SSL_CERT_FILE"
+COPY ./pkey "$SERVER_SSL_PKEY_FILE"
 
 # ---
-
+# Copy the Apache configuration file and enable the site
 COPY ./conf /etc/apache2/sites-available/000-default.conf
-RUN a2ensite 000-default
-RUN a2dissite default-ssl
+RUN a2ensite 000-default && a2dissite default-ssl
+
+# Restart Apache to apply changes
+RUN service apache2 restart
+
+# Make the ports 80 and 443 available to the world outside this container
+EXPOSE 80 443


### PR DESCRIPTION
by cleaning the apt cache after installing the required packages for the image. Also exposed ports 80 and 443 outside of the container.